### PR TITLE
Change FindingsListParamsMitigated to a string to fix the filter

### DIFF
--- a/defectdojo.gen.go
+++ b/defectdojo.gen.go
@@ -8251,7 +8251,7 @@ type FindingsListParamsJiraCreation time.Time
 type FindingsListParamsLastReviewed time.Time
 
 // FindingsListParamsMitigated defines parameters for FindingsList.
-type FindingsListParamsMitigated *string
+type FindingsListParamsMitigated string
 
 // FindingsListParamsO defines parameters for FindingsList.
 type FindingsListParamsO string

--- a/defectdojo.gen.go
+++ b/defectdojo.gen.go
@@ -8251,7 +8251,7 @@ type FindingsListParamsJiraCreation time.Time
 type FindingsListParamsLastReviewed time.Time
 
 // FindingsListParamsMitigated defines parameters for FindingsList.
-type FindingsListParamsMitigated time.Time
+type FindingsListParamsMitigated *string
 
 // FindingsListParamsO defines parameters for FindingsList.
 type FindingsListParamsO string
@@ -73336,4 +73336,3 @@ func GetSwagger() (swagger *openapi3.T, err error) {
 	}
 	return
 }
-


### PR DESCRIPTION
Jira link: https://doximity.atlassian.net/browse/APPSEC-1596

According to the [docs](https://defectdojo.services.dox.pub/api/v2/oa3/swagger-ui/), Mitigated should a string, and the value should be one of these:
1 - Today
2 - Past 7 days
3 - Past 30 days
4 - Past 90 days
5 - Current month
6 - Current year
7 - Past year

### QA

Tested the change on my local env using the code in this branch: https://github.com/doximity/dox-defectdojo-integrations/pull/34/files#diff-bce59c2b19b4f3c0a97d4575841c3e72fd727ca8ca74fe650960f0d5a870cf9cR254-R257